### PR TITLE
Add permission for UltraStaffChat

### DIFF
--- a/Permissions/Database.updb
+++ b/Permissions/Database.updb
@@ -6068,6 +6068,14 @@ UltraStaffChatPro+helperchat.mute+Allows the player to Mute player on Helper Cha
 UltraStaffChatPro+ultrastaffchatpro.update+Allows the player to have update message
 UltraStaffChatPro+ultrastaffchatpro.reload+Allows the player to reload the plugin
 UltraStaffChatPro+ultrastaffchatpro.debug+Allows the player to debug the plugin
+UltraStaffChatPro+multichannel.<name>.talk
+UltraStaffChatPro+multichannel.<name>.read
+UltraStaffChatPro+multichannel.<name>.toggle
+UltraStaffChatPro+multichannel.<name>.mute
+UltraStaffChatPro+multichannel.<name>.join
+UltraStaffChatPro+multichannel.<name>.leave
+UltraStaffChatPro+multichannel.<name>.switch
+UltraStaffChatPro+multichannel.<name>.list
 uSkyBlock+usb.admin.*+Controls player-cooldowns+/usb cooldown,/usb cd clear,/usb cd c
 uSkyBlock+usb.admin.addmember+Adds the player to the island+/usb is addmember [player] [islandleader]
 uSkyBlock+usb.admin.cache+Flushes all caches to files+/usb flush

--- a/Permissions/Database.updb
+++ b/Permissions/Database.updb
@@ -6052,30 +6052,22 @@ UltraRegionsDynmap+urd.command+Allows the player to use the main command of the 
 UltraRegionsDynmap+urd.reload+Allows the player to reload the plugin.+/urd reload
 UltraRegionsDynmap+urd.update+Allows the player to manually update the map.+/urd update
 UltraTags+ultratags.reload+Ability to use the reload command (reloads the plugin configuration)+/ultratags reload,/ut reload,/uts reload
-UltraStaffChatPro+staffchat.talk+Allows the player to Talk on the Staff Channel
-UltraStaffChatPro+staffchat.read+Allows the player to Read Message onn Staff Channel
-UltraStaffChatPro+staffchat.toggle+Allows the player to toggle+/sctoggle
-UltraStaffChatPro+staffchat.mute+Allows the player to mute on Staff Channel+/scmute
-UltraStaffChatPro+staffchat.join+Allows the player to join the Staff Channel
-UltraStaffChatPro+staffchat.leave+Allows the player to leave the Staff Channel
-UltraStaffChatPro+staffchat.switch+Allows the player to switch channel
-UltraStaffChatPro+staffchat.list+Allows the player to see the list+/stafflist
-UltraStaffChatPro+staffchat.list.exempt
-UltraStaffChatPro+helperchat.talk+Allows the player to Talk on Helper Channel
-UltraStaffChatPro+helperchat.read+Allows the player to Read message on Helper Channel
-UltraStaffChatPro+helperchat.toggle+Allows the player to Toggle
-UltraStaffChatPro+helperchat.mute+Allows the player to Mute player on Helper Channel
-UltraStaffChatPro+ultrastaffchatpro.update+Allows the player to have update message
-UltraStaffChatPro+ultrastaffchatpro.reload+Allows the player to reload the plugin
-UltraStaffChatPro+ultrastaffchatpro.debug+Allows the player to debug the plugin
-UltraStaffChatPro+multichannel.<name>.talk
-UltraStaffChatPro+multichannel.<name>.read
-UltraStaffChatPro+multichannel.<name>.toggle
-UltraStaffChatPro+multichannel.<name>.mute
-UltraStaffChatPro+multichannel.<name>.join
-UltraStaffChatPro+multichannel.<name>.leave
-UltraStaffChatPro+multichannel.<name>.switch
-UltraStaffChatPro+multichannel.<name>.list
+UltraStaffChatPro+staffchat.talk+Allows the player to talk in the staff chat.
+UltraStaffChatPro+staffchat.read+Allows the player to read messages in the staff chat.
+UltraStaffChatPro+staffchat.toggle+Allows the player to toggle the staff chat.+/sctoggle
+UltraStaffChatPro+staffchat.mute+Allows the player to mute another player in the staff chat.+/scmute
+UltraStaffChatPro+staffchat.join+Allows the player to join the staff chat.
+UltraStaffChatPro+staffchat.leave+Allows the player to leave the staff chat.
+UltraStaffChatPro+staffchat.switch+Allows the player to switch channels in the staff chat.
+UltraStaffChatPro+staffchat.list+Allows the player to see the staff list.+/sclist
+UltraStaffChatPro+staffchat.list.exempt+Allows the player to be exempt from the staff list.
+UltraStaffChatPro+helperchat.talk+Allows the player to talk in the helper chat.
+UltraStaffChatPro+helperchat.read+Allows the player to read messages in the helper chat.
+UltraStaffChatPro+helperchat.toggle+Allows the player to toggle the helper chat.
+UltraStaffChatPro+helperchat.mute+Allows the player to mute another player in the helper chat.
+UltraStaffChatPro+ultrastaffchatpro.update+Allows the player to receive update notifications.
+UltraStaffChatPro+ultrastaffchatpro.reload+Allows the player to reload the plugin.
+UltraStaffChatPro+ultrastaffchatpro.debug+Allows the player to debug the plugin.
 uSkyBlock+usb.admin.*+Controls player-cooldowns+/usb cooldown,/usb cd clear,/usb cd c
 uSkyBlock+usb.admin.addmember+Adds the player to the island+/usb is addmember [player] [islandleader]
 uSkyBlock+usb.admin.cache+Flushes all caches to files+/usb flush

--- a/Permissions/Database.updb
+++ b/Permissions/Database.updb
@@ -6052,6 +6052,22 @@ UltraRegionsDynmap+urd.command+Allows the player to use the main command of the 
 UltraRegionsDynmap+urd.reload+Allows the player to reload the plugin.+/urd reload
 UltraRegionsDynmap+urd.update+Allows the player to manually update the map.+/urd update
 UltraTags+ultratags.reload+Ability to use the reload command (reloads the plugin configuration)+/ultratags reload,/ut reload,/uts reload
+UltraStaffChatPro+staffchat.talk+Allows the player to Talk on the Staff Channel
+UltraStaffChatPro+staffchat.read+Allows the player to Read Message onn Staff Channel
+UltraStaffChatPro+staffchat.toggle+Allows the player to toggle+/sctoggle
+UltraStaffChatPro+staffchat.mute+Allows the player to mute on Staff Channel+/scmute
+UltraStaffChatPro+staffchat.join+Allows the player to join the Staff Channel
+UltraStaffChatPro+staffchat.leave+Allows the player to leave the Staff Channel
+UltraStaffChatPro+staffchat.switch+Allows the player to switch channel
+UltraStaffChatPro+staffchat.list+Allows the player to see the list+/stafflist
+UltraStaffChatPro+staffchat.list.exempt
+UltraStaffChatPro+helperchat.talk+Allows the player to Talk on Helper Channel
+UltraStaffChatPro+helperchat.read+Allows the player to Read message on Helper Channel
+UltraStaffChatPro+helperchat.toggle+Allows the player to Toggle
+UltraStaffChatPro+helperchat.mute+Allows the player to Mute player on Helper Channel
+UltraStaffChatPro+ultrastaffchatpro.update+Allows the player to have update message
+UltraStaffChatPro+ultrastaffchatpro.reload+Allows the player to reload the plugin
+UltraStaffChatPro+ultrastaffchatpro.debug+Allows the player to debug the plugin
 uSkyBlock+usb.admin.*+Controls player-cooldowns+/usb cooldown,/usb cd clear,/usb cd c
 uSkyBlock+usb.admin.addmember+Adds the player to the island+/usb is addmember [player] [islandleader]
 uSkyBlock+usb.admin.cache+Flushes all caches to files+/usb flush


### PR DESCRIPTION
Hello i do Pull request to add some perms to the data base

Link of the plugin : https://www.spigotmc.org/resources/ultrastaffchatpro.80461/
Link of the Perms : https://docs.hypera.dev/docs/ultrastaffchatpro#UltraStaffChatPro-default-permissions   Other perms is in the Config.yml, i don't know why is not with other

It's premium plugin :  name: UltraStaffChatPro
                                  version: 1.3.7
                                  authors: [JoshuaSing]
                                  main: dev.hypera.ultrastaffchatpro.spigot.USCPSpigot
                                  website: www.hypera.dev
                                  description: The most advanced and feature packed StaffChat plugin for Spigot & BungeeCord
                                  softdepend: [LuckPerms, PremiumVanish]


