### PR TITLE
Add Items In Chat Pro

### DIFF
--- a/Permissions/Database.updb
+++ b/Permissions/Database.updb
@@ -3445,6 +3445,10 @@ ItemFrameShops+ifs.user.useBuyAll+Non command: Buy All for one item.
 ItemFrameShops+ifs.user.useSellAll+Non command: Sell one stack for a item.
 ItemRestrict+ItemRestrict.admin+Bypass the item restrictions and access to the /itemrestrict reload command. Default to OP
 ItemRestrict+ItemRestrict.bypass+Bypass all the restrictions
+ItemsInChatPro+ItemInChat.send.item+Allows to use the [item] tag
+ItemsInChatPro+ItemInChat.send.inventory+Allows to use the [inventory] tag
+ItemsInChatPro+ItemInChat.send.gear+Allows to use the [gear] tag
+ItemsInChatPro+ItemInChat.send.gift+Allows to send an inventory gift through the chat+/iic gift <player>
 JEssentials+jessentials.*+Grants all permissions from the plugin
 JEssentials+jessentials.afk.auto+Marks the player as afk until they move/interact in-game
 JEssentials+jessentials.afk.kickexempt+Bypass afk kick


### PR DESCRIPTION
Plugin page (and permission page, scroll to the bottom of the page): https://www.spigotmc.org/resources/75786/

plugin.yml

```yml
name: "ItemInChatPro"
version: "2.5.0"
api-version: "1.13"
authors:
  - "Sh99"
main: dev.strawhats.iteminchatpro.ItemInChatPro
commands:
  sh99:
    usage: "/sh99"
    description: "Use it with tabcomplete feature to access the whole sh99-library management."
  iic:
    usage: "/iic <gift> <player>"
    description: "Use the internal iic functions."
  chatnotify:
    usage: "/chatnotify <on/off>"
    description: "Allows player to turn notifications in chat on or off, so other can tag them or not."
  iicinventorymirror:
    useage: "/inventorymirror <UUID-PLAYER>"
    description: "Open an inventory copy of a specific player when he had stored one before via [inventory]."
  iicgearmirror:
    useage: "/gearmirror <UUID-PLAYER>"
    description: "Open n gear copy of a specific player when he had stored one before via [gear]."
  iicgiftinventory:
    useage: "/giftinventory <UUID-PLAYER>"
    description: "Open n giftinventory of a specific player when he had stored one before via /iic gift <player>."
```

I hope I did this right 🥺