### PR TITLE
Add LWC Extended (LWCX) perms

### DIFF
--- a/Permissions/Database.updb
+++ b/Permissions/Database.updb
@@ -4433,6 +4433,36 @@ LoginSecurity+ls.admin+Allows the player to use admin commands.+/lac rmpass <pla
 LoginSecurity+ls.update+Allows the player to receive update notifications of the plugin.
 LongerMessages+longermessages.use+Permission to write longer messages
 Lovey+lovey.admin+Allow to reload the config and turn on/off the hearts.+/lovey admin reload,/lovey admin on,/lovey admin off
+LWC+lwc.*+Full administrative access to LWC
+LWC+lwc.protect+Gives the ability to basic LWC usage (almost everything except LWC admin.)
+LWC+lwc.admin+Gives you absolutely power over LWC. As an LWC admin, you have no restrictions.
+LWC+lwc.allcommands+Gives you access to every LWC command. Without lwc.admin or lwc.mod, you cannot open protections you do not own.
+LWC+lwc.shownotices+Shows LWC notices
+LWC+lwc.mod+Allows you to open anyone's protection but not remove them
+LWC+lwc.deny+Denys you access to any block LWC can protect. For example, with this permission set, you cannot open even unprotected chests (if protectable.)
+LWC+lwc.create.*+Allows you to create every basic protection (public, private, password.)+/lwc create <protection-type> [users]
+LWC+lwc.create.public+Allows you to create a public protection.+/lwc create public [users],/cpublic
+LWC+lwc.create.password+Allows you to create a password protection.+/lwc create password <password>,/cpassword <password>
+LWC+lwc.create.private+Allows you to create a private protection.+/lwc create private [users],/cprivate
+LWC+lwc.create.donation+Allows you to create a donation protection.+/lwc create donation [users],/cdonation
+LWC+lwc.create.display+Allows you to create a display protection.+/lwc create display [users],/cdisplay
+LWC+lwc.modify+Allows you to modify protections you own.+/lwc modify <usernames|groups|protection-type>,/cmodify <usernames|groups|protection-type>
+LWC+lwc.unlock+Allows you to unlock password-protected protections.+/lwc unlock <password>,/cunlock <password>
+LWC+lwc.info+Allows you to view the owner and other misc data on a protection.+/lwc info,/cinfo
+LWC+lwc.remove+Allows you to remove protections you own.+/lwc remove [protection|modes],/cremove
+LWC+lwc.flag.*+Gives you access to every usable flag.+/lwc flag <flag> <on|off>
+LWC+lwc.allflags+Gives you access to every usable flag.+/lwc flag <flag> <on|off>
+LWC+lwc.flag.redstone+Allows you to use the redstone flag, which enables or disables the use of redstone on a protection depending on plugin settings.+/credstone <on|off>,/lwc flag redstone <on|off>
+LWC+lwc.flag.magnet+Allows you to use the magnet flag, which makes a protection such as a chest suck up dropped items in a specific radius around it.+/cmagnet <on|off>,/lwc flag magnet <on|off>
+LWC+lwc.flag.autoclose+Allows a door to automatically close itself after 3 seconds (configurable.)+/cautoclose <on|off>,/lwc flag autoclose <on|off>
+LWC+lwc.flag.allowexplosions+Flag to allow a given protection to explode from explosions.
+LWC+lwc.mode.*+Gives you access to every usable mode, provided they are already disabled.+/lwc mode <mode>
+LWC+lwc.allmodes+Gives you access to every mode, provided they are already disabled.+/lwc mode <mode>
+LWC+lwc.mode.persist+Allows you to use the persist flag, which allows you to use commands repeatably.+/cpersist,/lwc mode persist
+LWC+lwc.mode.droptransfer+Allows you to use the drop transfer flag, which allows you to "drop" items into your chest from far away+/cdroptransfer <on|off|select|status>,/lwc mode droptransfer <on|off|select|status>
+LWC+lwc.mode.nospam+Toggle the ability to hide protection creation messages+/cnospam,/lwc mode nospam
+LWC+lwc.mode.nolock+Toggle the ability to create protections+/cnolock,/lwc mode nolock
+LWC+lwc.autoprotect+Allows you to auto protect LWC protections regardless of how LWC is configured
 Maintenance+maintenance.admin+Super permission that grants access to all perms.
 Maintenance+maintenance.bypass+Join the server during maintenance.
 Maintenance+maintenance.command+Use the "/maintenance" command (also required to use the subcommands).+/maintenance


### PR DESCRIPTION
<!-- REMOVE THE MODEL THAT DOES NOT APPLY TO YOUR PROPOSED CHANGES -->

## Adding Plugin
<!-- THIS SECTION IS RESERVED IF YOU ARE ADDING A NEW PLUGIN TO OUR DATABASE -->
**Plugin Name:** [LWC Extended](https://www.spigotmc.org/resources/lwc-extended.69551/)
**Permissions Page:** *https://github.com/pop4959/LWCX/wiki/Permissions*

**plugin.yml**
<!-- The plugin.yml can be found inside the plugin JAR, use WinZip or other programs to open it -->
```yml
name: LWC
main: com.griefcraft.lwc.LWCPlugin
version: 2.2.7-ad0f824
api-version: 1.13
author: Hidendra
authors: [pop4959, Me_Goes_RAWR]
website: https://www.spigotmc.org/resources/lwc-extended.69551/
description: >
             Inventory protection & management utilizing SQLite or MySQL as its backend
             Other blocks can also be protected individually, if configured.
load: startup
softdepend: [Vault, WorldEdit, WorldGuard, Towny, Factions]

commands:
  lwc:
    description: LWC's hub command to access everything
    usage: /<command>
  lock:
    description: Lock a block using LWC that only you can access
    usage: /<command>
  unlock:
    description: Remove a protection that was protected by LWC
    usage: /<command>
  cadmin:
    description: Administrate LWC
    usage: /<command>
    permission: lwc.admin
  cpublic:
    description: Create a protection that is accessible by anyone but protectable by no one.
    usage: /<command>
  cpassword:
    description: Create a protection that required a password to access it.
    usage: /<command> <password>
  cprivate:
    description: Create a protection that only you and specific groups or people can access.
    usage: /<command> <Users/Groups>
  cdonation:
    description: Creates a chest that can be deposited into, but only removed by player with access.
    usage: /<command>
  cdisplay:
    description: Creates a chest that can be looked into, but only removed by player with access.
    usage: /<command>
  cmodify:
    description: Modify an existing private protection.
    usage: /<command> <Modifications>
  cunlock:
    description: Unlock a password-protected protection.
    usage: /<command> <password>
  cinfo:
    description: View info on an existing protection.
    usage: /<command>
  cremove:
    description: Remove an existing protection.
    usage: /<command>
  cremoveall:
    description: Removes all protections owned by the player
    usage: /<command>
  climits:
    description: View your current protection limits.
    usage: /<command>
  credstone:
    description: Enable or disable redstone on a protection
    usage: /<command> <on|off>
  chopper:
    description: Enable or disable hoppers on a protection
    usage: /<command> <on|off>
  cmagnet:
    description: Enable or disable the magnet flag on an inventory protection, which makes it pick up items automatically around it.
    usage: /<command> <on|off>
  cdroptransfer:
    description: Configure drop transferring (allows you to transfer to a selected chest by dropping items.)
    usage: /<command> <select|on|off>
  cpersist:
    description: Toggle command persistence which allows you to use commands without retyping the command (e.g /cprivate)
    usage: /<command>
  cnolock:
    description: Toggle the ability to create protections
    usage: /<command>
  cnospam:
    description: Toggle the ability to hide protection creation messages
    usage: /<command>
  cexempt:
    description: Toggle protection exemption on an existing protection; disallows it from being removed by -remove, e.g /lwc admin expire -remove 2 weeks
    usage: /<command>
    permission: lwc.admin
  cautoclose:
    description: Flag a door to automatically close after 3 seconds (configurable.)
    usage: /<command>
  callowexplosions:
    description: Flag to allow a given protection to explode from explosions.
  ctnt:
    description: Flag to allow a given protection to explode from explosions.

permissions:

  lwc.*:
      description: Full administrative access to LWC
      default: false
      children:
          lwc.protect: true
          lwc.admin: true

  lwc.protect:
      description: Gives the ability to basic LWC usage (almost everything except LWC admin.)
      default: true

  lwc.admin:
      description: Gives you absolutely power over LWC. As an LWC admin, you have no restrictions.
      default: false
      children:
          lwc.allcommands: true

  lwc.allcommands:
      description: Gives you access to every LWC command. Without lwc.admin or lwc.mod, you cannot open protections you do not own.
      default: false

  lwc.shownotices:
      description: Shows LWC notices
      default: op

  lwc.mod:
      description: Allows you to open anyone's protection but not remove them
      default: false

  lwc.deny:
      description: Denys you access to any block LWC can protect. For example, with this permission set, you cannot open even unprotected chests (if protectable.)

  lwc.create.*:
      description: Allows you to create every basic protection (public, private, password.)
      children:
          lwc.create.public: true
          lwc.create.password: true
          lwc.create.private: true
          lwc.create.donation: true
          lwc.create.display: true
  lwc.create.public:
      description: Allows you to create a public protection.
  lwc.create.password:
      description: Allows you to create a password protection.
  lwc.create.private:
      description: Allows you to create a private protection.
  lwc.create.donation:
    description: Allows you to create a donation protection.
  lwc.create.display:
    description: Allows you to create a display protection.

  lwc.modify:
      description: Allows you to modify protections you own.
  lwc.unlock:
      description: Allows you to unlock password-protected protections.
  lwc.info:
      description: Allows you to view the owner and other misc data on a protection.
  lwc.remove:
      description: Allows you to remove protections you own.

  lwc.flag.*:
      description: Gives you access to every usable flag.
      children:
           lwc.allflags: true
  lwc.allflags:
      description: Gives you access to every usable flag.
      children:
           lwc.flag.redstone: true
           lwc.flag.magnet: true
           lwc.flag.autoclose: true
           lwc.flag.allowexplosions: true
  lwc.flag.redstone:
      description: Allows you to use the redstone flag, which enables or disables the use of redstone on a protection depending on plugin settings.
  lwc.flag.magnet:
      description: Allows you to use the magnet flag, which makes a protection such as a chest suck up dropped items in a specific radius around it.
  lwc.flag.autoclose:
      description: Allows a door to automatically close itself after 3 seconds (configurable.)

  lwc.mode.*:
      description: Gives you access to every usable mode, provided they are already disabled.
  lwc.allmodes:
      description: Gives you access to every mode, provided they are already disabled.
      children:
          lwc.mode.persist: true
          lwc.mode.droptransfer: true
          lwc.mode.nospam: true
          lwc.mode.nolock: true
  lwc.mode.persist:
      description: Allows you to use the persist flag, which allows you to use commands repeatably.
  lwc.mode.droptransfer:
      description: Allows you to use the drop transfer flag, which allows you to "drop" items into your chest from far away.

  lwc.autoprotect:
      default: false
      description: Allows you to auto protect LWC protections regardless of how LWC is configured
```
