### PR TITLE
Added DiscordSRV

### DIFF
--- a/Permissions/Database.updb
+++ b/Permissions/Database.updb
@@ -2132,6 +2132,29 @@ DiscordMinecraft+discordminecraft.discordsay+Sends a message to the specified ch
 DiscordMinecraft+discordminecraft.discordunlink+Unlinks your account from Discord.
 DiscordMinecraft+discordminecraft.sdc+Sends a chat message to Discord.
 DiscordMinecraft+discordminecraft.tdc+Toggles whether you see chat syncing with Discord.
+DiscordSRV+discordsrv.admin+parent permission of admin-related functions of DiscordSRV
+DiscordSRV+discordsrv.bcast+whether or not the player is able to broadcast messages to the main text channel of DiscordSRV+/discord broadcast <#ChannelID/#ChannelName> <Message>,/discord bc <#ChannelID/#ChannelName> <Message>
+DiscordSRV+discordsrv.chat+whether or not the user is able to have their chat forwarded to Discord
+DiscordSRV+discordsrv.debug+whether or not the player is able to run a debug report+/discord debug,/discord debugger <start [categories...]/stop/upload>
+DiscordSRV+discordsrv.discord+Allows access to the discord command+/discord,/discordsrv
+DiscordSRV+discordsrv.groupsyncwithcommands+whether or not the player can run a permission plugin command to force group sync to occur
+DiscordSRV+discordsrv.help+whether or not the player is able to display command help for DiscordSRV+/discord help,/discord ?
+DiscordSRV+discordsrv.language+whether or not the player can run /discord language to change the plugin's language+/discord language <Language> [-confirm],/discord lang <Language> [-confirm]
+DiscordSRV+discordsrv.link+whether or not the player is able to link their Minecraft account to their Discord account+/discord link
+DiscordSRV+discordsrv.link.others+whether or not the player is able to link other people's Minecraft accounts to Discord accounts+/discord link <Name/UUID/DiscordID/DiscordTag>
+DiscordSRV+discordsrv.linked+whether or not the player is able to check what Discord account their Minecraft account is linked to+,/discord linked
+DiscordSRV+discordsrv.linked.others+whether or not the player is able to check what Discord account other Minecraft accounts are linked to+/discord linked <Name/UUID/DiscordID/DiscordTag>
+DiscordSRV+discordsrv.nicknamesync+whether or not the player should have their nickname synced with Discord, if doing so is enabled in synchronization.yml
+DiscordSRV+discordsrv.player+parent permission of player-related functions of DiscordSRV
+DiscordSRV+discordsrv.reload+whether or not the player is able to reload DiscordSRV's configuration+/discord reload
+DiscordSRV+discordsrv.resync+whether or not the player can run /discord resync to force a resync of all groups/roles+/discord resync
+DiscordSRV+discordsrv.silentjoin+whether or not to have join messages for players with this permission to be silenced
+DiscordSRV+discordsrv.silentquit+whether or not to have quit messages for players with this permission to be silenced
+DiscordSRV+discordsrv.updatenotification+whether or not the player should be told if there's an update to DiscordSRV when joining
+DiscordSRV+discordsrv.sync.[group]+Groups that should be added to the player if their discord account is linked.
+DiscordSRV+discordsrv.sync.deny.[group]+Groups that should be removed from the player if their discord account is linked.
+DiscordSRV+discordsrv.unlink+whether or not the player is able to unlink their Minecraft account from their Discord account+/discord unlink,/discord clearlinked 
+DiscordSRV+discordsrv.unlink.Others+whether or not the player is able to unlink other people's Minecraft accounts from their Discord accounts+/discord unlink <Name/UUID> <DiscordID/DiscordTag>,/discord clearlinked <Name/UUID> <DiscordID/DiscordTag>
 Duels+duels.admin+Allows the player to use admin commands.
 Duels+duels.duel+Allows the player to duel.+/duel
 Duels+duels.kits.[kit]+Allows the player to use a specific kit if the usePermission option is enabled.

--- a/Permissions/Database.updb
+++ b/Permissions/Database.updb
@@ -2132,29 +2132,29 @@ DiscordMinecraft+discordminecraft.discordsay+Sends a message to the specified ch
 DiscordMinecraft+discordminecraft.discordunlink+Unlinks your account from Discord.
 DiscordMinecraft+discordminecraft.sdc+Sends a chat message to Discord.
 DiscordMinecraft+discordminecraft.tdc+Toggles whether you see chat syncing with Discord.
-DiscordSRV+discordsrv.admin+parent permission of admin-related functions of DiscordSRV
-DiscordSRV+discordsrv.bcast+whether or not the player is able to broadcast messages to the main text channel of DiscordSRV+/discord broadcast <#ChannelID/#ChannelName> <Message>,/discord bc <#ChannelID/#ChannelName> <Message>
-DiscordSRV+discordsrv.chat+whether or not the user is able to have their chat forwarded to Discord
-DiscordSRV+discordsrv.debug+whether or not the player is able to run a debug report+/discord debug,/discord debugger <start [categories...]/stop/upload>
+DiscordSRV+discordsrv.admin+Parent permission of admin-related functions of DiscordSRV
+DiscordSRV+discordsrv.bcast+Whether or not the player is able to broadcast messages to the main text channel of DiscordSRV+/discord broadcast <#ChannelID|#ChannelName> <Message>,/discord bc <#ChannelID|#ChannelName> <Message>
+DiscordSRV+discordsrv.chat+Whether or not the user is able to have their chat forwarded to Discord
+DiscordSRV+discordsrv.debug+Whether or not the player is able to run a debug report+/discord debug,/discord debugger <start|stop|upload>
 DiscordSRV+discordsrv.discord+Allows access to the discord command+/discord,/discordsrv
-DiscordSRV+discordsrv.groupsyncwithcommands+whether or not the player can run a permission plugin command to force group sync to occur
-DiscordSRV+discordsrv.help+whether or not the player is able to display command help for DiscordSRV+/discord help,/discord ?
-DiscordSRV+discordsrv.language+whether or not the player can run /discord language to change the plugin's language+/discord language <Language> [-confirm],/discord lang <Language> [-confirm]
-DiscordSRV+discordsrv.link+whether or not the player is able to link their Minecraft account to their Discord account+/discord link
-DiscordSRV+discordsrv.link.others+whether or not the player is able to link other people's Minecraft accounts to Discord accounts+/discord link <Name/UUID/DiscordID/DiscordTag>
-DiscordSRV+discordsrv.linked+whether or not the player is able to check what Discord account their Minecraft account is linked to+,/discord linked
-DiscordSRV+discordsrv.linked.others+whether or not the player is able to check what Discord account other Minecraft accounts are linked to+/discord linked <Name/UUID/DiscordID/DiscordTag>
-DiscordSRV+discordsrv.nicknamesync+whether or not the player should have their nickname synced with Discord, if doing so is enabled in synchronization.yml
-DiscordSRV+discordsrv.player+parent permission of player-related functions of DiscordSRV
-DiscordSRV+discordsrv.reload+whether or not the player is able to reload DiscordSRV's configuration+/discord reload
-DiscordSRV+discordsrv.resync+whether or not the player can run /discord resync to force a resync of all groups/roles+/discord resync
-DiscordSRV+discordsrv.silentjoin+whether or not to have join messages for players with this permission to be silenced
-DiscordSRV+discordsrv.silentquit+whether or not to have quit messages for players with this permission to be silenced
-DiscordSRV+discordsrv.updatenotification+whether or not the player should be told if there's an update to DiscordSRV when joining
+DiscordSRV+discordsrv.groupsyncwithcommands+Whether or not the player can run a permission plugin command to force group sync to occur
+DiscordSRV+discordsrv.help+Whether or not the player is able to display command help for DiscordSRV+/discord help,/discord ?
+DiscordSRV+discordsrv.language+Whether or not the player can run /discord language to change the plugin's language+/discord language <Language> [-confirm],/discord lang <Language> [-confirm]
+DiscordSRV+discordsrv.link+Whether or not the player is able to link their Minecraft account to their Discord account+/discord link
+DiscordSRV+discordsrv.link.others+Whether or not the player is able to link other people's Minecraft accounts to Discord accounts+/discord link <Name|UUID|DiscordID|DiscordTag>
+DiscordSRV+discordsrv.linked+Whether or not the player is able to check what Discord account their Minecraft account is linked to+,/discord linked
+DiscordSRV+discordsrv.linked.others+Whether or not the player is able to check what Discord account other Minecraft accounts are linked to+/discord linked <Name|UUID|DiscordID|DiscordTag>
+DiscordSRV+discordsrv.nicknamesync+Whether or not the player should have their nickname synced with Discord, if doing so is enabled in synchronization.yml
+DiscordSRV+discordsrv.player+Parent permission of player-related functions of DiscordSRV
+DiscordSRV+discordsrv.reload+Whether or not the player is able to reload DiscordSRV's configuration+/discord reload
+DiscordSRV+discordsrv.resync+Whether or not the player can run /discord resync to force a resync of all groups/roles+/discord resync
+DiscordSRV+discordsrv.silentjoin+Whether or not to have join messages for players with this permission to be silenced
+DiscordSRV+discordsrv.silentquit+Whether or not to have quit messages for players with this permission to be silenced
+DiscordSRV+discordsrv.updatenotification+Whether or not the player should be told if there's an update to DiscordSRV when joining
 DiscordSRV+discordsrv.sync.[group]+Groups that should be added to the player if their discord account is linked.
 DiscordSRV+discordsrv.sync.deny.[group]+Groups that should be removed from the player if their discord account is linked.
-DiscordSRV+discordsrv.unlink+whether or not the player is able to unlink their Minecraft account from their Discord account+/discord unlink,/discord clearlinked 
-DiscordSRV+discordsrv.unlink.Others+whether or not the player is able to unlink other people's Minecraft accounts from their Discord accounts+/discord unlink <Name/UUID> <DiscordID/DiscordTag>,/discord clearlinked <Name/UUID> <DiscordID/DiscordTag>
+DiscordSRV+discordsrv.unlink+Whether or not the player is able to unlink their Minecraft account from their Discord account+/discord unlink,/discord clearlinked 
+DiscordSRV+discordsrv.unlink.Others+Whether or not the player is able to unlink other people's Minecraft accounts from their Discord accounts+/discord unlink <Name|UUID> <DiscordID|DiscordTag>,/discord clearlinked <Name|UUID> <DiscordID|DiscordTag>
 Duels+duels.admin+Allows the player to use admin commands.
 Duels+duels.duel+Allows the player to duel.+/duel
 Duels+duels.kits.[kit]+Allows the player to use a specific kit if the usePermission option is enabled.


### PR DESCRIPTION
<!-- REMOVE THE MODEL THAT DOES NOT APPLY TO YOUR PROPOSED CHANGES -->

## Adding Plugin
**Plugin Name:** [DiscordSRV](https://www.spigotmc.org/resources/discordsrv.18494/)
**Permissions Page:** *https://docs.discordsrv.com/Permissions/*

**plugin.yml**
```
name: DiscordSRV
version: 1.26.0-SNAPSHOT
description: The most powerful, configurable, open-source Discord bridge plugin out there.
author: Scarsz
authors: [Androkai, Vankka]
website: https://github.com/DiscordSRV/DiscordSRV
api-version: 1.13

main: github.scarsz.discordsrv.DiscordSRV
database: false
loadbefore: [
  StaffPlus # Log4j conflicts with older versions
]
softdepend: [
  # Chat plugins
  Herochat, Legendchat, LunaChat, TownyChat, VentureChat,
  # Vanish plugins
  Essentials, PhantomAdmin, SuperVanish, VanishNoPacket, PremiumVanish,
  # Misc. plugins
  Multiverse-Core, Vault, PlaceholderAPI, mcMMO, LuckPerms, dynmap, Skript
]

commands:
  discord:
    aliases: [discordsrv]
    description: DiscordSRV commands
    usage: |
           /discord - Show the invite link of the Discord server
           /discord help/? - Show command list
           /discord link - Link Minecraft account with Discord account
           /discord unlink - Remove link between Minecraft and Discord account
           /discord linked - Show information about linking status
           /discord broadcast - Broadcast a message to Discord
           /discord debug - Send debug information to Gist
           /discord reload - Reload the plugin
           /discord resync - Resynchronizes all groups & roles
           /discord language - Changes the language of DiscordSRV to whatever is specified
           /discord debugger - A toggleable timings-like command to dump debug information to bin.scarsz.me
    permission: discordsrv.discord

permissions:
  discordsrv.player:
    description: parent permission of player-related functions of DiscordSRV
    default: true
    children:
      discordsrv.chat: true
      discordsrv.help: true
      discordsrv.link: true
      discordsrv.linked: true
      discordsrv.discord: true
      discordsrv.nicknamesync: true
  discordsrv.admin:
    description: parent permission of admin-related functions of DiscordSRV
    default: op
    children:
      discordsrv.player: true
      discordsrv.updatenotification: true
      discordsrv.bcast: true
      discordsrv.reload: true
      discordsrv.debug: true
      discordsrv.link.others: true
      discordsrv.linked.others: true
      discordsrv.unlink: true
      discordsrv.unlink.others: true
      discordsrv.resync: true
      discordsrv.groupsyncwithcommands: true
      discordsrv.language: true
  discordsrv.discord:
    description: allows access to the discord command
    default: true
  discordsrv.chat:
    description: whether or not the user is able to have their chat forwarded to Discord
    default: true
  discordsrv.silentjoin:
    description: whether or not to have join messages for players with this permission to be silenced
    default: false
  discordsrv.silentquit:
    description: whether or not to have quit messages for players with this permission to be silenced
    default: false
  discordsrv.help:
    description: whether or not the player is able to display command help for DiscordSRV
    default: true
  discordsrv.nicknamesync:
    description: whether or not the player should have their nickname synced with Discord, if doing so is enabled in synchronization.yml
    default: true
  discordsrv.updatenotification:
    description: whether or not the player should be told if there's an update to DiscordSRV when joining
    default: op
  discordsrv.bcast:
    description: whether or not the player is able to broadcast messages to the main text channel of DiscordSRV
    default: op
  discordsrv.reload:
    description: whether or not the player is able to reload DiscordSRV's configuration
    default: op
  discordsrv.debug:
    description: whether or not the player is able to run a debug report
    default: op
  discordsrv.link:
    description: whether or not the player is able to link their Minecraft account to their Discord account
    default: true
  discordsrv.link.others:
    description: whether or not the player is able to link other peoples Minecraft accounts to Discord accounts
    default: op
  discordsrv.unlink:
    description: whether or not the player is able to unlink their Minecraft account from their Discord account
    default: op
  discordsrv.unlink.others:
    description: whether or not the player is able to unlink other people's accounts
    default: op
  discordsrv.linked:
    description: whether or not the player is able to check what Discord account their Minecraft account is linked to
    default: true
  discordsrv.linked.others:
    description: whether or not the player is able to check what Discord account other Minecraft accounts are linked to
    default: op
  discordsrv.groupsyncwithcommands:
    description: whether or not the player can run a permission plugin command to force group sync to occur
    default: op
  discordsrv.resync:
    description: whether or not the player can run /discord resync to force a resync of all groups/roles
    default: op
  discordsrv.language:
    description: whether or not the player can run /discord language to change the plugin's language
    default: op

```